### PR TITLE
reset random number generator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import ora = require('ora');
 import {makeSSB} from './ssb';
 import {generateAuthors, generateMsgContent} from './generate';
 import {Opts, MsgsByType, Follows, Blocks} from './types';
-import {paretoSample} from './sample';
+import {paretoSample, reset as resetRNG} from './sample';
 import slimify from './slimify';
 import writeReportFile from './report';
 import * as defaults from './defaults';
@@ -49,6 +49,8 @@ export = async function generateFixture(opts?: Partial<Opts>) {
   const indexFeedTypes = opts?.indexFeedTypes ?? defaults.INDEX_FEED_TYPES;
   const verbose = opts?.verbose ?? defaults.VERBOSE;
   const progress = opts?.progress ?? defaults.PROGRESS;
+
+  resetRNG();
 
   const spinner = progress ? ora('Setting up').start() : null;
   const authorsKeys = generateAuthors(seed, numAuthors);


### PR DESCRIPTION
This module has state: https://github.com/ssb-ngi-pointer/ssb-fixtures/blob/4520fbf3a059b06f942ad47568185472ae419772/src/sample.ts#L7-L8

We have to reset it before it's re-run (within the same process).